### PR TITLE
Abstracted YomButton

### DIFF
--- a/mobileApp/lib/ui/Abstractions/yomButton.dart
+++ b/mobileApp/lib/ui/Abstractions/yomButton.dart
@@ -1,0 +1,98 @@
+import 'package:YouOweMe/ui/Abstractions/yomSpinner.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:rxdart/rxdart.dart';
+import 'package:basics/basics.dart';
+
+class YomButton extends StatelessWidget {
+  final YomButtonController controller;
+
+  final Widget child;
+
+  final Widget loading;
+
+  final Widget error;
+
+  final Widget success;
+
+  final VoidCallback onPressed;
+
+  final Color backgroundColor;
+
+  YomButton({
+    @required this.controller,
+    @required this.child,
+    @required this.onPressed,
+    this.loading,
+    this.error,
+    this.success,
+    this.backgroundColor,
+  }) : assert(controller != null);
+
+  @override
+  Widget build(BuildContext context) {
+    Widget _buttonChild;
+    Color _buttonBackgroundColor =
+        this.backgroundColor ?? Theme.of(context).accentColor;
+    Brightness _buttonBrightness =
+        ThemeData.estimateBrightnessForColor(_buttonBackgroundColor);
+
+    Color _iconsColor;
+    if (_buttonBrightness == Brightness.dark) {
+      _iconsColor = Theme.of(context).scaffoldBackgroundColor;
+    } else {
+      _iconsColor = Theme.of(context).accentColor;
+    }
+    return StreamBuilder<YomButtonState>(
+        stream: controller.state,
+        builder: (BuildContext context, snapshot) {
+          YomButtonState buttonState = snapshot?.data ?? YomButtonState.ACTIVE;
+          if (buttonState == YomButtonState.ACTIVE) {
+            _buttonChild = child;
+          } else if (buttonState == YomButtonState.LOADING) {
+            _buttonChild = this.loading ??
+                YOMSpinner(
+                  brightness: _buttonBrightness,
+                );
+          } else if (buttonState == YomButtonState.ERROR) {
+            _buttonChild = this.error ??
+                Icon(
+                  Icons.error_outline,
+                  color: _iconsColor,
+                );
+          } else if (buttonState == YomButtonState.SUCCESS) {
+            _buttonChild = this.success ??
+                Icon(
+                  Icons.check_circle_outline,
+                  color: _iconsColor,
+                );
+          }
+
+          return CupertinoButton(
+            color: _buttonBackgroundColor,
+            child: AnimatedSwitcher(
+                duration: Duration(milliseconds: 200), child: _buttonChild),
+            onPressed: onPressed,
+          );
+        });
+  }
+}
+
+enum YomButtonState {
+  ACTIVE,
+//  INACTIVE,
+  LOADING,
+  ERROR,
+  SUCCESS
+}
+
+class YomButtonController {
+  BehaviorSubject<YomButtonState> _yomButtonSubject =
+      BehaviorSubject.seeded(YomButtonState.ACTIVE);
+
+  Stream<YomButtonState> get state => _yomButtonSubject.stream;
+
+  void setButtonState(YomButtonState state) {
+    _yomButtonSubject.add(state);
+  }
+}

--- a/mobileApp/lib/ui/Abstractions/yomButton.dart
+++ b/mobileApp/lib/ui/Abstractions/yomButton.dart
@@ -5,8 +5,7 @@ import 'package:rxdart/rxdart.dart';
 import 'package:basics/basics.dart';
 
 /// YomButton is a abtracted Button to be used along with
-/// `YomButtonController` to easily show microanimated
-/// 
+/// `YomButtonController` to easily show microanimations.
 class YomButton extends StatelessWidget {
   final YomButtonController controller;
 
@@ -74,7 +73,9 @@ class YomButton extends StatelessWidget {
           return CupertinoButton(
             color: _buttonBackgroundColor,
             child: AnimatedSwitcher(
-                duration: Duration(milliseconds: 200), child: _buttonChild),
+                switchInCurve: Curves.easeInSine,
+                duration: Duration(milliseconds: 200),
+                child: _buttonChild),
             onPressed: onPressed,
           );
         });
@@ -111,10 +112,12 @@ class YomButtonController {
 
   void showError() {
     setButtonState(YomButtonState.ERROR);
+    Future.delayed(Duration(seconds: 2), () => this.showActive());
   }
 
   void showSuccess() {
     setButtonState(YomButtonState.SUCCESS);
+    Future.delayed(Duration(seconds: 2), () => this.showActive());
   }
 
   void setButtonState(YomButtonState state) {

--- a/mobileApp/lib/ui/Abstractions/yomButton.dart
+++ b/mobileApp/lib/ui/Abstractions/yomButton.dart
@@ -4,6 +4,9 @@ import 'package:flutter/material.dart';
 import 'package:rxdart/rxdart.dart';
 import 'package:basics/basics.dart';
 
+/// YomButton is a abtracted Button to be used along with
+/// `YomButtonController` to easily show microanimated
+/// 
 class YomButton extends StatelessWidget {
   final YomButtonController controller;
 
@@ -86,11 +89,33 @@ enum YomButtonState {
   SUCCESS
 }
 
+/// Controller To be used in conjunction with
+/// `YomButton`
 class YomButtonController {
   BehaviorSubject<YomButtonState> _yomButtonSubject =
       BehaviorSubject.seeded(YomButtonState.ACTIVE);
 
   Stream<YomButtonState> get state => _yomButtonSubject.stream;
+
+  void showActive() {
+    setButtonState(YomButtonState.ACTIVE);
+  }
+
+  void showLoading({Future future}) {
+    setButtonState(YomButtonState.LOADING);
+    print(future.isNotNull);
+    if (future.isNotNull)
+      future.then((value) => this.showActive(),
+          onError: (a) => this.showError());
+  }
+
+  void showError() {
+    setButtonState(YomButtonState.ERROR);
+  }
+
+  void showSuccess() {
+    setButtonState(YomButtonState.SUCCESS);
+  }
 
   void setButtonState(YomButtonState state) {
     _yomButtonSubject.add(state);

--- a/mobileApp/lib/ui/Abstractions/yomButton.dart
+++ b/mobileApp/lib/ui/Abstractions/yomButton.dart
@@ -5,7 +5,8 @@ import 'package:rxdart/rxdart.dart';
 import 'package:basics/basics.dart';
 
 /// YomButton is a abtracted Button to be used along with
-/// `YomButtonController` to easily show microanimations.
+/// `YomButtonController` to easily show and manage microanimations.
+/// If a `YomButtonController` is not passed acts like any other Button in the tree.
 class YomButton extends StatelessWidget {
   final YomButtonController controller;
 
@@ -22,14 +23,14 @@ class YomButton extends StatelessWidget {
   final Color backgroundColor;
 
   YomButton({
-    @required this.controller,
+    this.controller,
     @required this.child,
     @required this.onPressed,
     this.loading,
     this.error,
     this.success,
     this.backgroundColor,
-  }) : assert(controller != null);
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -46,7 +47,7 @@ class YomButton extends StatelessWidget {
       _iconsColor = Theme.of(context).accentColor;
     }
     return StreamBuilder<YomButtonState>(
-        stream: controller.state,
+        stream: controller?.state ?? YomButtonController().state,
         builder: (BuildContext context, snapshot) {
           YomButtonState buttonState = snapshot?.data ?? YomButtonState.ACTIVE;
           if (buttonState == YomButtonState.ACTIVE) {
@@ -82,13 +83,7 @@ class YomButton extends StatelessWidget {
   }
 }
 
-enum YomButtonState {
-  ACTIVE,
-//  INACTIVE,
-  LOADING,
-  ERROR,
-  SUCCESS
-}
+enum YomButtonState { ACTIVE, LOADING, ERROR, SUCCESS }
 
 /// Controller To be used in conjunction with
 /// `YomButton`

--- a/mobileApp/lib/ui/NewOwe/newOwe.dart
+++ b/mobileApp/lib/ui/NewOwe/newOwe.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:YouOweMe/resources/notifiers/meNotifier.dart';
 import 'package:YouOweMe/ui/Abstractions/yomAvatar.dart';
+import 'package:YouOweMe/ui/Abstractions/yomButton.dart';
 import 'package:YouOweMe/ui/NewOwe/contactSelector.dart';
 import 'package:contacts_service/contacts_service.dart';
 import 'package:flutter/cupertino.dart';
@@ -28,6 +29,8 @@ class _NewOweState extends State<NewOwe> {
 
   final BehaviorSubject<Contact> selectedContactController = BehaviorSubject();
 
+  final YomButtonController yomButtonController = YomButtonController();
+
   final _formKey = GlobalKey<FormState>();
 
   String titleValidator(String text) {
@@ -51,7 +54,8 @@ class _NewOweState extends State<NewOwe> {
   @override
   Widget build(BuildContext context) {
     TargetPlatform platform = Theme.of(context).platform;
-    void addNewOwe() {
+    void addNewOwe() async {
+      yomButtonController.showLoading();
       try {
         bool isValidated = _formKey.currentState.validate();
         if (!isValidated) {
@@ -71,7 +75,7 @@ class _NewOweState extends State<NewOwe> {
           mobileNo = '+91' + mobileNo;
         }
         print(mobileNo);
-        Provider.of<MeNotifier>(context, listen: false)
+        await Provider.of<MeNotifier>(context, listen: false)
             .graphQLClient
             .mutate(MutationOptions(
                 documentNode: gql(newOweMutation),
@@ -83,14 +87,15 @@ class _NewOweState extends State<NewOwe> {
                     "displayName": selectedContactController.value.displayName
                   }
                 },
-                onError: (e) {
-                  print(e);
-                },
                 onCompleted: (a) {
                   Provider.of<MeNotifier>(context, listen: false).refresh();
+                  yomButtonController.showSuccess();
                   Navigator.pop(context);
                 }));
-      } catch (e) {}
+      } catch (e) {
+        print(e);
+        yomButtonController.showError();
+      }
     }
 
     Future<bool> onWilPopScope() async {
@@ -264,9 +269,9 @@ class _NewOweState extends State<NewOwe> {
                         Container(
                           height: 60,
                           width: 400,
-                          child: CupertinoButton(
-                              color: Theme.of(context).accentColor,
+                          child: YomButton(
                               child: Text('Done'),
+                              controller: yomButtonController,
                               onPressed: addNewOwe),
                         )
                     ],


### PR DESCRIPTION
### What Does this PR do?.
This PR brings in another Abstraction `YomButton` and its partner `YomButtonController` .

### Describe In brief the solution / approach you've gone with.
This is a simple controller based Button, which allows the controller to change the state of the button.
The Possible state of the Button are.
```dart
enum YomButtonState { ACTIVE, LOADING, ERROR, SUCCESS }
```

Example:
```dart
final YomButtonController yomButtonController = YomButtonController();
YomButton(
 child: Text('Done'),
 controller: yomButtonController,
 onPressed:  () {
  yomButtonController.showLoading();
 }
),
```

### Describe alternatives you may have considered
Other alternatives would be to write a ton a code each time to get a button with a spinner.

### Additional context / quirks
Will have to extend more Widgets (For ex: FAB) with this to reuse more code.
