### PR TITLE
Implement dataloader

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1093,6 +1093,11 @@
         "array-find-index": "^1.0.1"
       }
     },
+    "dataloader": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-2.0.0.tgz",
+      "integrity": "sha512-YzhyDAwA4TaQIhM5go+vCLmU0UikghC/t9DTQYZR2M/UvZ1MdOhPezSDZcjj9uqQJOMqjLcpWtyW2iNINdlatQ=="
+    },
     "date-and-time": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/date-and-time/-/date-and-time-0.13.1.tgz",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -3224,6 +3224,11 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "typedi": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/typedi/-/typedi-0.8.0.tgz",
+      "integrity": "sha512-/c7Bxnm6eh5kXx2I+mTuO+2OvoWni5+rXA3PhXwVWCtJRYmz3hMok5s1AKLzoDvNAZqj/Q/acGstN0ri5aQoOA=="
+    },
     "typescript": {
       "version": "3.9.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.2.tgz",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -507,9 +507,9 @@
       "integrity": "sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA=="
     },
     "@types/semver": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.1.0.tgz",
-      "integrity": "sha512-pOKLaubrAEMUItGNpgwl0HMFPrSAFic8oSVIvfu1UwcgGNmNyK9gyhBHKmBnUTwwVvpZfkzUC0GaMgnL6P86uA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.2.0.tgz",
+      "integrity": "sha512-TbB0A8ACUWZt3Y6bQPstW9QNbhNeebdgLX4T/ZfkrswAfUzRiXrgd9seol+X379Wa589Pu4UEx9Uok0D4RjRCQ==",
       "requires": {
         "@types/node": "*"
       }
@@ -3179,9 +3179,9 @@
       "integrity": "sha512-tTSkux6IGPnUGUd1XAZHcpu85MOkIl5zX49pO+jfsie3eP0B6pyhOlLXm3cAC6T7s+euSDDUUV+Acop5WmtkVg=="
     },
     "type-graphql": {
-      "version": "1.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/type-graphql/-/type-graphql-1.0.0-rc.1.tgz",
-      "integrity": "sha512-kQJz2eGOKXZI5idrhhaR04lhdwI8kwdvGRHXlwoiAwLhilq0ajuJQxNGeCTXxDKUwAP1XuhBVCr6Wh4Qp3g2NQ==",
+      "version": "1.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/type-graphql/-/type-graphql-1.0.0-rc.2.tgz",
+      "integrity": "sha512-zhZc93d/0ufrSnhwvVcgtXABVXwRoHMKNVbZiXcb+2Xv1RFNmZWhm4EtqsD9LzRVCWcVXpKRKTq8O4csdfuRUQ==",
       "requires": {
         "@types/glob": "^7.1.1",
         "@types/node": "*",

--- a/server/package.json
+++ b/server/package.json
@@ -25,7 +25,8 @@
         "graphql": "^15.0.0",
         "graphql-firestore-subscriptions": "^1.0.1",
         "reflect-metadata": "^0.1.13",
-        "type-graphql": "^1.0.0-rc.1"
+        "type-graphql": "^1.0.0-rc.1",
+        "typedi": "^0.8.0"
     },
     "devDependencies": {
         "@types/express": "^4.17.6",

--- a/server/package.json
+++ b/server/package.json
@@ -25,7 +25,7 @@
         "graphql": "^15.0.0",
         "graphql-firestore-subscriptions": "^1.0.1",
         "reflect-metadata": "^0.1.13",
-        "type-graphql": "^1.0.0-rc.1",
+        "type-graphql": "^1.0.0-rc.2",
         "typedi": "^0.8.0"
     },
     "devDependencies": {

--- a/server/package.json
+++ b/server/package.json
@@ -18,6 +18,7 @@
         "apollo-server": "^2.13.1",
         "axios": "^0.19.2",
         "class-validator": "^0.12.2",
+        "dataloader": "^2.0.0",
         "dotenv": "^8.2.0",
         "express": "^4.17.1",
         "firebase-admin": "^8.12.1",

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -16,8 +16,6 @@ const main = async () => {
     context: ({ req, connection }) => {
       const requestId = Math.floor(Math.random() * Number.MAX_SAFE_INTEGER);
       console.log('Creating Container', requestId)
-      const used = process.memoryUsage().heapUsed / 1024 / 1024;
-      console.log(`The Memory Being Used ${Math.round(used * 100) / 100} MB`);
       let context: ApplicationContext = {
         req,
         requestId

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -4,7 +4,7 @@ import "./utils/envConfig"
 
 import { generateSchema } from "./schema"
 import { ApplicationContext } from "./utils/appContext"
-import Container from "typedi"
+import { Container } from "typedi"
 
 const main = async () => {
   const schema = await generateSchema()

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -16,6 +16,8 @@ const main = async () => {
     context: ({ req, connection }) => {
       const requestId = Math.floor(Math.random() * Number.MAX_SAFE_INTEGER);
       console.log('Creating Container', requestId)
+      const used = process.memoryUsage().heapUsed / 1024 / 1024;
+      console.log(`The Memory Being Used ${Math.round(used * 100) / 100} MB`);
       let context: ApplicationContext = {
         req,
         requestId

--- a/server/src/modules/Owe/OweResolver.ts
+++ b/server/src/modules/Owe/OweResolver.ts
@@ -3,6 +3,7 @@ import { Owe, OweState } from "../../models/Owe";
 import { User } from "../../models/User";
 import { UserResolver } from "../User/UserResolver";
 import { DocumentReference } from "@google-cloud/firestore"
+import { RequestContainer, UserDataLoader } from "../User/userResolver/userLoader";
 
 @Resolver(Owe)
 export class OweResolver {
@@ -30,20 +31,20 @@ export class OweResolver {
     @FieldResolver(() => User, {
         name: "issuedBy",
     })
-    async issuedByFieldResolver(@Root() owe: Owe) {
+    async issuedByFieldResolver(@Root() owe: Owe, @RequestContainer() userDataLoader: UserDataLoader) {
         const oweRef = owe.documenmentRef
         const issuedByRef = oweRef.parent.parent
         const issedByUserId = issuedByRef!.id
-        const issuedByUser = await new UserResolver().getUser(issedByUserId)
+        const issuedByUser = await new UserResolver().getUser(issedByUserId, userDataLoader)
         return issuedByUser
     }
 
     @FieldResolver(() => User, {
         name: "issuedTo",
     })
-    async issuedToFieldResolver(@Root() owe: Owe) {
+    async issuedToFieldResolver(@Root() owe: Owe, @RequestContainer() userDataLoader: UserDataLoader) {
         const userId: string = owe.issuedToID
-        const user = await new UserResolver().getUser(userId)
+        const user = await new UserResolver().getUser(userId, userDataLoader)
         return user
     }
 }

--- a/server/src/modules/Owe/OweResolver.ts
+++ b/server/src/modules/Owe/OweResolver.ts
@@ -4,6 +4,7 @@ import { User } from "../../models/User";
 import { UserResolver } from "../User/UserResolver";
 import { DocumentReference } from "@google-cloud/firestore"
 import { RequestContainer, UserDataLoader } from "../User/userResolver/userLoader";
+import { mapUserSnapshot } from "../User/userResolver/userSnapshotMap";
 
 @Resolver(Owe)
 export class OweResolver {
@@ -35,7 +36,11 @@ export class OweResolver {
         const oweRef = owe.documenmentRef
         const issuedByRef = oweRef.parent.parent
         const issedByUserId = issuedByRef!.id
-        const issuedByUser = await new UserResolver().getUser(issedByUserId, userDataLoader)
+        const issuedByUserSnapshot = await userDataLoader.load(issedByUserId)
+        if (!issuedByUserSnapshot) {
+            throw Error("User Snapshot from loader is Null in oweResolver")
+        }
+        const issuedByUser = mapUserSnapshot(issuedByUserSnapshot)
         return issuedByUser
     }
 
@@ -44,7 +49,11 @@ export class OweResolver {
     })
     async issuedToFieldResolver(@Root() owe: Owe, @RequestContainer() userDataLoader: UserDataLoader) {
         const userId: string = owe.issuedToID
-        const user = await new UserResolver().getUser(userId, userDataLoader)
-        return user
+        const issuedToUserSnapshot = await userDataLoader.load(userId)
+        if (!issuedToUserSnapshot) {
+            throw Error("User Snapshot from loader is Null in oweResolver")
+        }
+        const issuedToUser = mapUserSnapshot(issuedToUserSnapshot)
+        return issuedToUser
     }
 }

--- a/server/src/modules/User/MeResolver.ts
+++ b/server/src/modules/User/MeResolver.ts
@@ -1,10 +1,11 @@
-import { Resolver, Query, Authorized, Ctx, Subscription, Publisher, PubSub, Root } from "type-graphql";
+import { Resolver, Query, Authorized, Ctx, Subscription, Publisher, PubSub, Root, Info } from "type-graphql";
 import { ApplicationContext } from "../../utils/appContext";
 import { firestore } from "../../db/firebase";
 import { User } from "../../models/User";
 import { Timestamp } from "@google-cloud/firestore";
 import { UserResolver } from "./UserResolver";
 import { userTopicGenerator } from "./userResolver/userTopic";
+import { RequestContainer, UserDataLoader } from "./userResolver/userLoader";
 
 
 @Resolver()
@@ -13,10 +14,9 @@ export class MeResolver {
     @Query(() => User, {
         name: "Me"
     })
-    async getMe(@Ctx() context: ApplicationContext): Promise<User> {
-        console.log(context.req.headers.authorization + "wpwza")
+    async getMe(@Ctx() context: ApplicationContext, @RequestContainer() userDataLoader: UserDataLoader): Promise<User> {
         const userId = context.req.headers.authorization!
-        const user = await new UserResolver().getUser(userId)
+        const user = await new UserResolver().getUser(userId, userDataLoader)
         return user
     }
 

--- a/server/src/modules/User/MeResolver.ts
+++ b/server/src/modules/User/MeResolver.ts
@@ -6,6 +6,7 @@ import { Timestamp } from "@google-cloud/firestore";
 import { UserResolver } from "./UserResolver";
 import { userTopicGenerator } from "./userResolver/userTopic";
 import { RequestContainer, UserDataLoader } from "./userResolver/userLoader";
+import { mapUserSnapshot } from "./userResolver/userSnapshotMap";
 
 
 @Resolver()
@@ -16,7 +17,11 @@ export class MeResolver {
     })
     async getMe(@Ctx() context: ApplicationContext, @RequestContainer() userDataLoader: UserDataLoader): Promise<User> {
         const userId = context.req.headers.authorization!
-        const user = await new UserResolver().getUser(userId, userDataLoader)
+        const userSnapshot = await userDataLoader.load(userId)
+        if (!userSnapshot) {
+            throw Error("User Snapshot from loader is Null in MeResolver")
+        }
+        const user = mapUserSnapshot(userSnapshot)
         return user
     }
 

--- a/server/src/modules/User/UserResolver.ts
+++ b/server/src/modules/User/UserResolver.ts
@@ -15,16 +15,7 @@ export class UserResolver {
         const usersRef = firestore.collection('users')
         const usersSnapshot = await usersRef.get()
         const users = usersSnapshot.docs.map((userSnapshot) => {
-            const userData = userSnapshot.data()
-            const created: Timestamp = userData!.created;
-            const user: User = {
-                id: userSnapshot.id,
-                name: userData.name,
-                image: userData.image,
-                mobileNo: userData.mobile_no,
-                fcmToken: userData.fcm_token,
-                created: created.toDate()
-            }
+            const user: User = mapUserSnapshot(userSnapshot)
             return user
         })
         return users

--- a/server/src/modules/User/UserResolver.ts
+++ b/server/src/modules/User/UserResolver.ts
@@ -4,6 +4,7 @@ import { User } from "../../models/User"
 import { DocumentReference, Timestamp, DocumentSnapshot } from "@google-cloud/firestore"
 import { Owe, OweState } from "../../models/Owe"
 import { RequestContainer, UserDataLoader } from "./userResolver/userLoader"
+import { mapUserSnapshot } from "./userResolver/userSnapshotMap"
 
 @Resolver(User)
 export class UserResolver {
@@ -34,19 +35,7 @@ export class UserResolver {
     })
     async getUser(@Arg("id") id: string, @RequestContainer() userDataLoader: UserDataLoader): Promise<User> {
         const userSnapshot = await userDataLoader.load(id) as DocumentSnapshot
-        const userData = userSnapshot.data()
-        if (!userSnapshot.exists) {
-            throw Error("User Does Not Exist")
-        }
-        const created: Timestamp = userData!.created
-        const user: User = {
-            id: userSnapshot.id,
-            name: userData!.name,
-            image: userData!.image,
-            mobileNo: userData!.mobile_no,
-            fcmToken: userData!.fcm_token,
-            created: created.toDate()
-        }
+        const user: User = mapUserSnapshot(userSnapshot)
         return user
     }
 

--- a/server/src/modules/User/UserResolver.ts
+++ b/server/src/modules/User/UserResolver.ts
@@ -1,8 +1,9 @@
 import { firestore } from "../../db/firebase"
 import { Query, Resolver, FieldResolver, Root, Arg, Authorized, Int } from "type-graphql"
 import { User } from "../../models/User"
-import { DocumentReference, Timestamp } from "@google-cloud/firestore"
+import { DocumentReference, Timestamp, DocumentSnapshot } from "@google-cloud/firestore"
 import { Owe, OweState } from "../../models/Owe"
+import { RequestContainer, UserDataLoader } from "./userResolver/userLoader"
 
 @Resolver(User)
 export class UserResolver {
@@ -31,9 +32,8 @@ export class UserResolver {
     @Query(() => User, {
         nullable: true
     })
-    async getUser(@Arg("id") id: string): Promise<User> {
-        const userRef = firestore.collection('users').doc(id)
-        const userSnapshot = await userRef.get()
+    async getUser(@Arg("id") id: string, @RequestContainer() userDataLoader: UserDataLoader): Promise<User> {
+        const userSnapshot = await userDataLoader.load(id) as DocumentSnapshot
         const userData = userSnapshot.data()
         if (!userSnapshot.exists) {
             throw Error("User Does Not Exist")

--- a/server/src/modules/User/updateUserResolver.ts
+++ b/server/src/modules/User/updateUserResolver.ts
@@ -3,6 +3,7 @@ import { User } from "../../models/User";
 import { UpdateUserInputType } from "./updateUser/updateUserInputType";
 import { firestore } from "../../db/firebase";
 import { UserResolver } from "./UserResolver"
+import { RequestContainer, UserDataLoader } from "./userResolver/userLoader";
 
 @Resolver(User)
 export class UpdateUserResolver {
@@ -10,7 +11,7 @@ export class UpdateUserResolver {
     @Mutation(() => User, {
         description: "This Mutation gives one the ability to update values of a `User`. Currently only supports updating the name and the fcm_token",
     })
-    async updateUser(@Arg("data") data: UpdateUserInputType) {
+    async updateUser(@Arg("data") data: UpdateUserInputType, @RequestContainer() userDataLoader: UserDataLoader) {
         const userId = data.id
         const userRef = firestore.collection('users').doc(userId)
         try {
@@ -23,7 +24,7 @@ export class UpdateUserResolver {
                 ...(fcmToken && { fcm_token: fcmToken }),
                 ...updateData
             })
-            let user = await new UserResolver().getUser(userId)
+            let user = await new UserResolver().getUser(userId, userDataLoader)
             return user
         } catch (e) {
             throw e

--- a/server/src/modules/User/updateUserResolver.ts
+++ b/server/src/modules/User/updateUserResolver.ts
@@ -4,6 +4,7 @@ import { UpdateUserInputType } from "./updateUser/updateUserInputType";
 import { firestore } from "../../db/firebase";
 import { UserResolver } from "./UserResolver"
 import { RequestContainer, UserDataLoader } from "./userResolver/userLoader";
+import { mapUserSnapshot } from "./userResolver/userSnapshotMap";
 
 @Resolver(User)
 export class UpdateUserResolver {
@@ -24,7 +25,11 @@ export class UpdateUserResolver {
                 ...(fcmToken && { fcm_token: fcmToken }),
                 ...updateData
             })
-            let user = await new UserResolver().getUser(userId, userDataLoader)
+            let userSnapshot = await userDataLoader.load(userId)
+            if(!userSnapshot) {
+                throw Error("User Snapshot from loader is Null in updateResolver")
+            }
+            let user = mapUserSnapshot(userSnapshot)
             return user
         } catch (e) {
             throw e

--- a/server/src/modules/User/userResolver/userLoader.ts
+++ b/server/src/modules/User/userResolver/userLoader.ts
@@ -1,0 +1,31 @@
+import Container, { Service } from "typedi";
+import DataLoader from "dataloader"
+import { firestore } from "../../../db/firebase";
+import { FieldPath, DocumentSnapshot, DocumentData } from "@google-cloud/firestore";
+import { createParamDecorator } from "type-graphql";
+import { ApplicationContext } from "../../../utils/appContext";
+
+@Service()
+export class UserDataLoader extends DataLoader<string, DocumentSnapshot | undefined> {
+    constructor() {
+        super(async (ids) => {
+            console.log("Asked For ID's ",ids)
+            const usersPromise: Promise<DocumentSnapshot<DocumentData>>[] = ids.map(async (id) => {
+                return await firestore.collection('users').doc(id).get()
+            })
+            const users = await Promise.all(usersPromise)
+            console.log("Dataloader Response", users.length)
+            return ids.map((id) => users.find((user) => user.id === id));
+        });
+    }
+}
+
+export function RequestContainer(): ParameterDecorator {
+    return function (target: Object, propertyName: string | symbol, index: number) {
+        return createParamDecorator<ApplicationContext>(({ context, info }) => {
+            const paramtypes = Reflect.getMetadata('design:paramtypes', target, propertyName);
+            const requestContainer = Container.of(context.requestId);
+            return requestContainer.get(paramtypes[index]);
+        })(target, propertyName, index);
+    };
+}

--- a/server/src/modules/User/userResolver/userLoader.ts
+++ b/server/src/modules/User/userResolver/userLoader.ts
@@ -9,7 +9,7 @@ import { ApplicationContext } from "../../../utils/appContext";
 export class UserDataLoader extends DataLoader<string, DocumentSnapshot | undefined> {
     constructor() {
         super(async (ids) => {
-            console.log("Asked For ID's ",ids)
+            console.log("Asked For ID's ", ids)
             const usersPromise: Promise<DocumentSnapshot<DocumentData>>[] = ids.map(async (id) => {
                 return await firestore.collection('users').doc(id).get()
             })
@@ -22,7 +22,7 @@ export class UserDataLoader extends DataLoader<string, DocumentSnapshot | undefi
 
 export function RequestContainer(): ParameterDecorator {
     return function (target: Object, propertyName: string | symbol, index: number) {
-        return createParamDecorator<ApplicationContext>(({ context, info }) => {
+        return createParamDecorator<ApplicationContext>(({ context }) => {
             const paramtypes = Reflect.getMetadata('design:paramtypes', target, propertyName);
             const requestContainer = Container.of(context.requestId);
             return requestContainer.get(paramtypes[index]);

--- a/server/src/modules/User/userResolver/userSnapshotMap.ts
+++ b/server/src/modules/User/userResolver/userSnapshotMap.ts
@@ -1,0 +1,20 @@
+import { DocumentSnapshot, Timestamp } from "@google-cloud/firestore";
+import { User } from "../../../models/User";
+
+type userSnapshotMapType = (snapshot: DocumentSnapshot) => User;
+
+export const mapUserSnapshot: userSnapshotMapType = snapshot => {
+    const userData = snapshot.data()
+    if (!snapshot.exists) {
+        throw Error("User Does Not Exist")
+    }
+    const created: Timestamp = userData!.created
+    return {
+        id: snapshot.id,
+        name: userData!.name,
+        image: userData!.image,
+        mobileNo: userData!.mobile_no,
+        fcmToken: userData!.fcm_token,
+        created: created.toDate()
+    }
+}

--- a/server/src/modules/User/userResolver/userTopic.ts
+++ b/server/src/modules/User/userResolver/userTopic.ts
@@ -2,21 +2,13 @@ import { PubSubFire } from "../../../db/pubSubFire"
 import { Timestamp } from "@google-cloud/firestore"
 import { User } from "../../../models/User"
 import { firestore } from "../../../db/firebase"
+import { mapUserSnapshot } from "./userSnapshotMap"
 
 const userTopicGenerator = (id: string) => {
     try {
         PubSubFire.registerHandler(`user_subscription_${id}`.toString(), broadcast => {
             return firestore.collection('users').doc(id).onSnapshot((snapshot) => {
-                const userData = snapshot.data()
-                const created: Timestamp = userData!.created
-                const user: User = {
-                    id: snapshot.id,
-                    name: userData!.name,
-                    image: userData!.image,
-                    fcmToken: userData!.fcm_token,
-                    mobileNo: userData!.mobile_no,
-                    created: created.toDate()
-                }
+                const user: User = mapUserSnapshot(snapshot)
                 broadcast(user)
             })
         })

--- a/server/src/schema.ts
+++ b/server/src/schema.ts
@@ -1,8 +1,10 @@
-import { buildSchema } from "type-graphql"
+import { buildSchema, ResolverData } from "type-graphql"
 import "reflect-metadata"
 
 import { customAuthChecker } from "./utils/authChecker"
 import { PubSubFire } from "./db/pubSubFire"
+import { ApplicationContext } from "./utils/appContext"
+import { Container } from "typedi"
 
 
 const generateSchema = async () => {
@@ -10,7 +12,8 @@ const generateSchema = async () => {
         resolvers: [__dirname + '/modules/**/*.{ts,js}'],
         authChecker: customAuthChecker,
         dateScalarMode: "timestamp",
-        pubSub: PubSubFire
+        pubSub: PubSubFire,
+        container: (({ context }: ResolverData<ApplicationContext>) => Container.of(context.requestId))
     })
 }
 

--- a/server/src/utils/appContext.ts
+++ b/server/src/utils/appContext.ts
@@ -2,4 +2,5 @@ import { Request } from 'express'
 
 export interface ApplicationContext {
     req: Request;
+    requestId: number
 }


### PR DESCRIPTION
### What Does this PR do?.
Adds Dataloader to the server to batch and cache `User` queries.

### Describe In brief the solution / approach you've gone with.
The approach used here uses [Dataloader](https://github.com/graphql/dataloader) of which a new instance is created on every new connection.

The Dataloader is then made available using dependency injection mentioned here.
https://github.com/MichalLytek/type-graphql/issues/51#issuecomment-626719854 

### Describe alternatives you may have considered
* A alternate would have been to add Dataloader to the appContext, but the problem with that is would have been difficult to manage and expand overtime.

* Use the dataloader over larger time, use it more as a cache with a different lifecycle than that of the request. 
**Pros of this approach.**
 This would mean significantly lesser hits to the database and that's amazing.

** Cons of this approach**
Would be difficult to maintain the lifecycle of the Dataloader and may lead to significant memory leaks and hell.

### Additional context / quirks
Add any other context, screenshots, or quirks about the implmentation here.
